### PR TITLE
Adding gunzip filter.

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,9 @@ func server(port int, maxSinceInterval int, dumpRequests bool, mapper mapping.No
 	r := mux.NewRouter()
 
 	r.HandleFunc("/lists/notifications", resources.ReadNotifications(mapper, nextLink, db, maxSinceInterval))
-	r.HandleFunc("/lists/{uuid}", resources.FilterSyntheticTransactions(resources.WriteNotification(dumpRequests, mapper, db))).Methods("PUT")
+
+	gunzipped := resources.UnzipGzip(resources.WriteNotification(dumpRequests, mapper, db))
+	r.HandleFunc("/lists/{uuid}", resources.FilterSyntheticTransactions(gunzipped)).Methods("PUT")
 
 	r.HandleFunc("/__health", resources.Health(db))
 	r.HandleFunc(status.GTGPath, resources.GTG(db))

--- a/main.go
+++ b/main.go
@@ -108,8 +108,8 @@ func server(port int, maxSinceInterval int, dumpRequests bool, mapper mapping.No
 
 	r.HandleFunc("/lists/notifications", resources.ReadNotifications(mapper, nextLink, db, maxSinceInterval))
 
-	gunzipped := resources.UnzipGzip(resources.WriteNotification(dumpRequests, mapper, db))
-	r.HandleFunc("/lists/{uuid}", resources.FilterSyntheticTransactions(gunzipped)).Methods("PUT")
+	write := resources.Filter(resources.WriteNotification(dumpRequests, mapper, db)).FilterSyntheticTransactions().Gunzip().Build()
+	r.HandleFunc("/lists/{uuid}", write).Methods("PUT")
 
 	r.HandleFunc("/__health", resources.Health(db))
 	r.HandleFunc(status.GTGPath, resources.GTG(db))

--- a/resources/filters.go
+++ b/resources/filters.go
@@ -11,8 +11,36 @@ import (
 const synthTidPrefix = "SYNTHETIC-REQ-MON"
 const tidHeader = "X-Request-Id"
 
+// Filters contains the composed chain
+type Filters struct {
+	next func(w http.ResponseWriter, r *http.Request)
+}
+
+// Filter creates a new composable filter.
+func Filter(next func(w http.ResponseWriter, r *http.Request)) Filters {
+	return Filters{next}
+}
+
 // FilterSyntheticTransactions will filter out incoming requests if they have a synthetic prefix.
-func FilterSyntheticTransactions(next func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
+func (f Filters) FilterSyntheticTransactions() Filters {
+	next := f.next
+	f.next = filterSyntheticTransactions(next)
+	return f
+}
+
+// Gunzip pre-processes the request body if it's gzipped.
+func (f Filters) Gunzip() Filters {
+	next := f.next
+	f.next = gunzip(next)
+	return f
+}
+
+// Build returns the final chained handler
+func (f Filters) Build() func(w http.ResponseWriter, r *http.Request) {
+	return f.next
+}
+
+func filterSyntheticTransactions(next func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tid := r.Header.Get(tidHeader)
 		if tid == "" {
@@ -31,8 +59,7 @@ func FilterSyntheticTransactions(next func(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// UnzipGzip pre-processes the request body if it's gzipped.
-func UnzipGzip(next func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
+func gunzip(next func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Encoding") == "gzip" {
 			unzipped, err := gzip.NewReader(r.Body)

--- a/resources/filters_test.go
+++ b/resources/filters_test.go
@@ -20,7 +20,7 @@ func TestFilterSyntheticTransactions(t *testing.T) {
 	req.Header.Add(tidHeader, synthTidPrefix+"_a-fake-tid-which-should-be-rejected-if-all-goes-well")
 
 	w := httptest.NewRecorder()
-	FilterSyntheticTransactions(next)(w, req)
+	Filter(next).FilterSyntheticTransactions().Build()(w, req)
 
 	assert.Equal(t, 200, w.Code)
 	t.Log("Request was filtered.")
@@ -37,12 +37,10 @@ func TestAllowsNormalTransactions(t *testing.T) {
 	req.Header.Add(tidHeader, "tid_123761283")
 
 	w := httptest.NewRecorder()
-	FilterSyntheticTransactions(next)(w, req)
+	Filter(next).FilterSyntheticTransactions().Build()(w, req)
 
 	assert.Equal(t, 200, w.Code)
-	if !passed {
-		t.Fatal("Failed to reach next handler!")
-	}
+	assert.True(t, passed)
 }
 
 func TestAllowsNoTID(t *testing.T) {
@@ -53,7 +51,7 @@ func TestAllowsNoTID(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://nothing/at/all", nil)
 
 	w := httptest.NewRecorder()
-	FilterSyntheticTransactions(next)(w, req)
+	Filter(next).FilterSyntheticTransactions().Build()(w, req)
 
 	assert.Equal(t, 400, w.Code)
 }
@@ -67,7 +65,7 @@ func TestFailUnzip(t *testing.T) {
 	req.Header.Add("Content-Encoding", "gzip")
 
 	w := httptest.NewRecorder()
-	UnzipGzip(next)(w, req)
+	Filter(next).Gunzip().Build()(w, req)
 
 	assert.Equal(t, 400, w.Code)
 }
@@ -87,10 +85,8 @@ func TestUnzipOk(t *testing.T) {
 	req.Header.Add("Content-Encoding", "gzip")
 
 	w := httptest.NewRecorder()
-	UnzipGzip(next)(w, req)
+	Filter(next).Gunzip().Build()(w, req)
 
 	assert.Equal(t, 200, w.Code)
-	if !passed {
-		t.Fatal("Failed to reach next handler!")
-	}
+	assert.True(t, passed)
 }


### PR DESCRIPTION
Despite saying it does, golang doesn't unzip gzipped requests. So we have to do that for it.