### PR TITLE
Updated gtg endpoint response headers

### DIFF
--- a/resources/health.go
+++ b/resources/health.go
@@ -7,6 +7,13 @@ import (
 	"github.com/Financial-Times/list-notifications-rw/db"
 )
 
+const (
+	contentType      = "Content-Type"
+	plainText        = "text/plain; charset=US-ASCII"
+	cacheControl     = "Cache-control"
+	noCache          = "no-cache"
+)
+
 // Health returns a handler for the standard FT healthchecks
 func Health(db db.DB) func(w http.ResponseWriter, r *http.Request) {
 	return fthealth.Handler("list-notifications-rw", "Notifies clients of updates to UPP Lists.", getHealthchecks(db)[0])
@@ -15,6 +22,8 @@ func Health(db db.DB) func(w http.ResponseWriter, r *http.Request) {
 // GTG returns a handler for a standard GTG endpoint.
 func GTG(db db.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(contentType, plainText)
+		w.Header().Set(cacheControl, noCache)
 		_, err := pingMongo(db)()
 		if err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
According to the gtg standard ( https://docs.google.com/document/d/11paOrAIl9eIOqUEERc9XMaaL3zouJDdkmb-gExYFnw0/edit ) the response should have **Content-Type:text/plain; charset=US-ASCII** and **Cache-Control:no-cache** headers 


Tested in xp