### PR TITLE
Fixed notifications return for empty slice

### DIFF
--- a/resources/read.go
+++ b/resources/read.go
@@ -54,7 +54,7 @@ func ReadNotifications(mapper mapping.NotificationsMapper, nextLink mapping.Next
 			return
 		}
 
-		var results []model.PublicNotification
+		results := make([]model.PublicNotification, 0)
 		for i, n := range *notifications {
 			if i >= reader.GetLimit() {
 				break

--- a/resources/read_test.go
+++ b/resources/read_test.go
@@ -81,7 +81,8 @@ func TestReadNoNotifications(t *testing.T) {
 
 	mockClient := new(MockClient)
 
-	var mockNotifications []model.InternalNotification
+	//Important Ft.com expects [] not nil
+	mockNotifications := make([]model.InternalNotification, 0)
 
 	mockClient.On("ReadNotifications", 0, mockSince).Return(&mockNotifications, nil)
 
@@ -96,6 +97,7 @@ func TestReadNoNotifications(t *testing.T) {
 
 	results := page.Notifications
 
+	assert.NotNil(t, results, "Result must be empty, but not nil")
 	assert.Len(t, results, 0)
 	mockClient.AssertExpectations(t)
 }


### PR DESCRIPTION
# Description

Fixed bug introduced in 0.4.0 where upon reaching an empty page the pre-0.4.0 returned [] but 0.4.0 returned null

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-4262)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
